### PR TITLE
only exec virtualenv script if path exists

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,8 +5,10 @@ import sys, os
 root_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
 os.chdir(root_dir)
 
+# TODO: this should be moved into the wsgi file
 activate_this = os.path.join(root_dir, 'venv2', 'bin', 'activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
+if os.path.exists(activate_this):
+    execfile(activate_this, dict(__file__=activate_this))
 
 sys.path.pop(0)
 sys.path.insert(0, os.getcwd())


### PR DESCRIPTION
Running activate_this.py should be happening in the wsgi file, not in manage.py, since anyone working with the app locally with likely have their virtualenv in some other location.

This fix allows users to run the app locally while preserving the current behavior on the live site.
