### PR TITLE
issue #2: optimize loading comments on discussion page

### DIFF
--- a/flask_application/controllers/talk.py
+++ b/flask_application/controllers/talk.py
@@ -83,6 +83,7 @@ def thread(id):
 	See a comment thread
 	"""
 	thread = Thread.objects.get_or_404(id=id)
+	thread.populate_comment_creators()
 	form = CommentForm(exclude=['creator'])
 	return render_template('talk/detail.html',
 		thread = thread,

--- a/flask_application/helpers.py
+++ b/flask_application/helpers.py
@@ -118,7 +118,11 @@ def parse_pos(s):
     else:
         return a[0], a[1], b[0], b[1]
 
-
+def merge_dicts(*dict_args):
+    result = {}
+    for dictionary in dict_args:
+        result.update(dictionary)
+    return result
 
 
 def write_opf(meta_info, primary_id=None, path=None):


### PR DESCRIPTION
This should speed up the discussion page. Hard to say by how much. You just have to try it and see. In the event that it breaks anything (very unlikely), just comment out the one line I added in `flask_application/controllers/talk.py`.

MongoEngine provides a select_related() call that should do what populate_comment_creators() in this pull request effectively does. But I couldn't get it to work. I wonder if select_related() can't/won't traverse this relationship: 

comments = db.ListField(db.EmbeddedDocumentField(Comment))

Probably worth upgrading the MongoEngine library at some later date, but that's a bigger task than I wanted to take on right now for this optimization.
