### PR TITLE
fix list of 'created' collections in dropdown

### DIFF
--- a/flask_application/forms/collection.py
+++ b/flask_application/forms/collection.py
@@ -56,7 +56,7 @@ class CollectionQuerySetSelectField(QuerySetSelectField):
 		self.queryset = {}
 		self.queryset['following'] = Collection.objects.filter(supercollection__exists=False, followers=current_user.get_id()).order_by('title')
 		self.queryset['contributing'] = Collection.objects.filter(supercollection__exists=False, editors=current_user.get_id()).order_by('title')
-		self.queryset['created'] = Collection.objects.filter(supercollection__exists=False, followers=current_user.get_id()).order_by('title')
+		self.queryset['created'] = Collection.objects.filter(supercollection__exists=False, creator=current_user.get_id()).order_by('title')
 
 	def process_formdata(self, valuelist):
 		"""


### PR DESCRIPTION
The 'created' group in the collections dropdown doesn't actually show the collections you created. It incorrectly shows the ones you're following.

This PR actually reverts a line change made to this file a long time ago, in the commit linked below. I think that was a typo, but you might want to look it over to double check.

https://github.com/aaaaarg/webapp-2013/commit/6ac565637bdd8954c743de2f04a86e15e676290a#diff-ceff9af80b5ccace7ba0183a86bdd099R59
