### PR TITLE
coerce markupsafe.Markup objects to unicode strs

### DIFF
--- a/flask_application/controllers/collection.py
+++ b/flask_application/controllers/collection.py
@@ -154,7 +154,7 @@ def add_thing(thing_id):
 		return jsonify({
 			'result':'success', 
 			'message':'Added to <a href="%s">%s</a>!' % (url_for('collection.detail', id=collection.id), collection.title), 
-			'collection':get_template_attribute('collection/macros.html', 'show_collections_list_item')(collection, thing)})
+			'collection':unicode(get_template_attribute('collection/macros.html', 'show_collections_list_item')(collection, thing))})
 	return jsonify({'result':'error', 'message':'Sorry, there was a problem'})
 
 

--- a/flask_application/controllers/frontend.py
+++ b/flask_application/controllers/frontend.py
@@ -61,7 +61,7 @@ def follow(type, id):
 			cached.delete()
 	return jsonify({
 		'result': 'success',
-		'message': get_template_attribute('frontend/macros.html', 'unfollow')(model)
+		'message': unicode(get_template_attribute('frontend/macros.html', 'unfollow')(model))
 	})
 
 
@@ -92,7 +92,7 @@ def unfollow(type, id):
 			cached.delete()
 	return jsonify({
 		'result': 'success',
-		'message': get_template_attribute('frontend/macros.html', 'follow')(model)
+		'message': unicode(get_template_attribute('frontend/macros.html', 'follow')(model))
 	})	
 
 

--- a/flask_application/controllers/talk.py
+++ b/flask_application/controllers/talk.py
@@ -152,7 +152,7 @@ def follow(id):
 	collection.add_follower(user)
 	return jsonify({
 			'result': 'success',
-			'message': get_template_attribute('collection/macros.html', 'unfollow')(collection)
+			'message': unicode(get_template_attribute('collection/macros.html', 'unfollow')(collection))
 			})
 
 
@@ -171,7 +171,7 @@ def unfollow(id):
 	collection.remove_follower(user)
 	return jsonify({
 			'result': 'success',
-			'message': get_template_attribute('collection/macros.html', 'follow')(collection)
+			'message': unicode(get_template_attribute('collection/macros.html', 'follow')(collection))
 			})
 
 


### PR DESCRIPTION
On my machine, jsonify() does html-escaping of markupsafe.Markup objects (which is what get_template_attribute() returns) when it renders them as strings. The browser chokes on these json responses. This happens when trying to Follow/Unfollow, and when adding a thing to a collection. Oddly enough, this doesn't happen on the live site. I don't know what the difference might be.

The fix is to coerce the objects to unicode strings before they reach jsonify().
