### PR TITLE
don't remove click handler for popovers when clicked

### DIFF
--- a/flask_application/templates/bootstrap/macros.html
+++ b/flask_application/templates/bootstrap/macros.html
@@ -59,7 +59,7 @@
     $(".popover-trigger.remote").click(function() {
         el = $(this);
         // Show loading...
-        el.unbind('click').popover('show');
+        el.popover('show');
         $.get(el.attr('data-poload'), function(response) {
             el.attr('data-content', response);
             el.popover('show');


### PR DESCRIPTION
Currently, if you click away from a popover, you can't click the + link a second time to bring it up again. This fixes that.
