### PR TITLE
improve searching logic in opensearch api

### DIFF
--- a/flask_application/controllers/frontend.py
+++ b/flask_application/controllers/frontend.py
@@ -320,10 +320,10 @@ def opensearch_search():
 	q = request.args.get('q')
 	start = request.args.get('start')
 
-	num = 10
+	num = 25
 
 	results = elastic.search('thing',
-		query={ 'title^3,short_description,description,makers_string':q },
+		query=q,
 		start=start,
 		num=num)
 


### PR DESCRIPTION
this fixes the prob of no results being returned if you search for a combination of author and title keywords through the opensearch api.

the code now triggers a 'query_string' search in ES instead of a phrase match search, which was too restrictive. also, bumped up num of results to return.
