### PR TITLE
rm type=phrase and unnecessary escaping from multi_match ES queries

### DIFF
--- a/flask_application/elastic.py
+++ b/flask_application/elastic.py
@@ -24,13 +24,12 @@ class ES(object):
 		if query:
 			if type(query) is dict:
 				field_str = query.keys()[0]
-				query_str = re.escape(query.values()[0])
+				query_str = query.values()[0]
 				if ',' in field_str:
 					query_body = {
 						"multi_match" : {
 							"fields" : field_str.split(','),
 							"query" : query_str,
-							"type" : "phrase"
 						}
 					}
 				else:


### PR DESCRIPTION
This PR removes the 'type' parameter on 'multi_match' ES searches. This was added back in Sept:

https://github.com/aaaaarg/webapp-2013/commit/75e648f650418db381f8e35e8b6b81b397f069a0

I think it was to support searching for phrases in 'page' docs, but that code path isn't currently used by page searching anyway (those are 'match_phrase' searches).

This change fixes overly restrictive searches in the web app. If you "right city" nothing comes up, but "right to the city" does.
