### PR TITLE
improve search more

### DIFF
--- a/flask_application/controllers/frontend.py
+++ b/flask_application/controllers/frontend.py
@@ -146,7 +146,7 @@ def search(type=False):
 	start = (page-1)*num
 	if type=='things':
 		results = elastic.search('thing', 
-			query={ 'title^3,short_description,description':query }, 
+			query={ 'title^3,short_description,description,makers_string':query },
 			start=start, 
 			num=num)
 		content = get_template_attribute('frontend/macros.html', 'search_results')(results, 'thing.detail')			

--- a/flask_application/elastic.py
+++ b/flask_application/elastic.py
@@ -30,6 +30,8 @@ class ES(object):
 						"multi_match" : {
 							"fields" : field_str.split(','),
 							"query" : query_str,
+							"type" : "cross_fields",
+							"operator" : "and",
 						}
 					}
 				else:


### PR DESCRIPTION
I'm still dissatisfied with how search is working. Some results are missing while it's puzzling why other results show up.

The case in particular I'm interested in, is a search for title + author fragments ("sexuality foucault" or "phenomenology spirit hegel"). I do these all the time, and I suspect other people do too. To make that case work better, here are 2 changes:

1) I added makers_string to /search/thing searches.

2) I tweaked multi_match. "cross_fields" treats the fields as if they were one big field. In this context, the "and" operator is effectively applied across those fields (rather than within a single field).

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-cross-fields
