### PR TITLE
use ipfs-api library; fix download link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ rfc3987==1.3.4
 pdfminer==20140328
 elasticsearch==1.6.0
 python-stdnum==1.0
+ipfs-api==0.2.2


### PR DESCRIPTION
The main benefit of using this lib is that you can run "ipfs daemon" as a different user than the one running the webapp. Adding files via the API means you don't have to worry about file permissions on the ipfs store.

Remember to run "pip install -r requirements.txt" in the virtualenv.

Also fixed the download link (I was mistaken about how the paths work).
